### PR TITLE
Ss encoding branch

### DIFF
--- a/lib/watirmark/version.rb
+++ b/lib/watirmark/version.rb
@@ -1,5 +1,5 @@
 module Watirmark
   module Version
-    STRING = '6.0.0'
+    STRING = '6.0.1'
   end
 end

--- a/lib/watirmark/version.rb
+++ b/lib/watirmark/version.rb
@@ -1,5 +1,5 @@
 module Watirmark
   module Version
-    STRING = '6.0.1'
+    STRING = '6.0.0'
   end
 end

--- a/watirmark.gemspec
+++ b/watirmark.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir['spec/**/*.rb']
   s.executables = 'watirmark'
   s.require_paths = %w(lib)
-  s.add_dependency('watir', '= 6.8.1')
+  s.add_dependency('watir', '= 6.10.0')
   s.add_dependency('american_date', '~> 1.1.0')
   s.add_dependency('logger', '~> 1.2.8')
   s.add_dependency('uuid', '~> 2.3.7')


### PR DESCRIPTION
Tested watir 6.10.0 on my VM.  I ran 6 CPT tags and all were green. Note: the text locator is deprecated and I can work on updating those once we confirm we want to keep 6.10.0.